### PR TITLE
Octave skipping in sdf

### DIFF
--- a/src/draw-scene.js
+++ b/src/draw-scene.js
@@ -19,7 +19,7 @@ export function drawScene() {
     gl.uniform1f(uniforms.largeRadius, torus.radius.large / zoom.val);
     gl.uniform1f(uniforms.smallRadius, torus.radius.small / zoom.val);
 
-    gl.uniform1i(uniforms.terrainDetail, Math.min(Math.max(torus.terrain.detail.base - zoom.precise, torus.terrain.detail.min), torus.terrain.detail.max));
+    gl.uniform1ui(uniforms.terrainDetail, Math.min(Math.max(torus.terrain.detail.base - zoom.precise, torus.terrain.detail.min), torus.terrain.detail.max));
     gl.uniform1f(uniforms.terrainSize, torus.terrain.size * zoom.val);
     gl.uniform1f(uniforms.terrainHeight, torus.terrain.height / zoom.val);
 

--- a/src/shader.js
+++ b/src/shader.js
@@ -53,7 +53,7 @@ float seaLevel = 0.0;
 float minDistance = 0.0001;
 float maxDistance = 100.0;
 int maxSteps = 100;
-int stepsUntilShuffle = 70;
+float stepScale = 0.5;
 
 float temperature = 0.62;
 float ambience = float(${light.ambience});
@@ -77,7 +77,7 @@ void main() {
     float closestDistance = distance;
 
     for (int i = 0; i < maxSteps && abs(distance) > minDistance && distance < maxDistance; i++) {
-        pos += distance / float(max(1, i - stepsUntilShuffle)) * ray;
+        pos += stepScale * distance * ray;
         distance = sdf(pos, uTerrainDetail);
 
         if (abs(distance) < closestDistance) {

--- a/src/shader.js
+++ b/src/shader.js
@@ -162,7 +162,7 @@ float sdf(vec4 pos, uint maxOctaves) {
         channel += 1u;
     }
 
-    return distance - max(height, -minDistance);
+    return distance - max(height, -2.0 * minDistance);
 }
 
 vec4 getColor(float altitude, float temperature, float shade) {


### PR DESCRIPTION
Implement octave skipping in the sdf. Octave skipping is the algorithm that iteratively approximates the distance from a point to the scene by first computing the distance from the point to a smooth torus. Then, if the point far enough from the torus that all remaining layers of noise would never reach it, the algorithm terminates. Otherwise, it computes the next largest layer of noise and repeats.

This change improved performance by a factor of 3 when most of the rays miss the torus and had little impact when the camera was very close to the surface.